### PR TITLE
Disable powerful mode by cycling off then restoring previous mode

### DIFF
--- a/custom_components/eldom/eldom_boiler.py
+++ b/custom_components/eldom/eldom_boiler.py
@@ -1,6 +1,7 @@
 """Eldom boiler objects."""
 
 from abc import ABC, abstractmethod
+import asyncio
 import logging
 
 from eldom.client import Client as EldomClient
@@ -143,6 +144,10 @@ class EldomBoiler(ABC):
     @abstractmethod
     async def enable_powerful_mode(self) -> None:
         """Enable the boiler's powerful mode."""
+
+    @abstractmethod
+    async def disable_powerful_mode(self) -> None:
+        """Disable the boiler's powerful mode."""
 
     @abstractmethod
     async def reset_energy_usage(self) -> None:
@@ -304,6 +309,13 @@ class FlatEldomBoiler(EldomBoiler):
             self.device_id
         )
 
+    async def disable_powerful_mode(self) -> None:
+        """Disable the boiler's powerful mode."""
+        previous_mode = self.current_operation
+        await self.turn_off()
+        await asyncio.sleep(1)
+        await self.set_operation_mode(previous_mode)
+
     async def reset_energy_usage(self) -> None:
         """Reset the energy usage of the boiler."""
         self._flat_boiler_details.EnergyD = 0.0
@@ -462,6 +474,13 @@ class SmartEldomBoiler(EldomBoiler):
         await self._eldom_client.smart_boiler.set_smart_boiler_powerful_mode_on(
             self.device_id
         )
+
+    async def disable_powerful_mode(self) -> None:
+        """Disable the boiler's powerful mode."""
+        previous_mode = self.current_operation
+        await self.turn_off()
+        await asyncio.sleep(1)
+        await self.set_operation_mode(previous_mode)
 
     async def reset_energy_usage(self) -> None:
         """Reset the energy usage of the boiler."""
@@ -658,6 +677,13 @@ class NaturelaEldomBoiler(EldomBoiler):
         await self._eldom_client.naturela_boiler.set_naturela_boiler_powerful_mode_on(
             self.device_id
         )
+
+    async def disable_powerful_mode(self) -> None:
+        """Disable the boiler's powerful mode."""
+        previous_mode = self.current_operation
+        await self.turn_off()
+        await asyncio.sleep(1)
+        await self.set_operation_mode(previous_mode)
 
     async def reset_energy_usage(self) -> None:
         """Reset the energy usage of the boiler."""

--- a/custom_components/eldom/manifest.json
+++ b/custom_components/eldom/manifest.json
@@ -10,6 +10,6 @@
   "issue_tracker": "https://github.com/qbaware/homeassistant-eldom/issues",
   "requirements": ["pyeldom==2.1.0"],
   "ssdp": [],
-  "version": "7.1.0",
+  "version": "7.2.0",
   "zeroconf": []
 }

--- a/custom_components/eldom/switch.py
+++ b/custom_components/eldom/switch.py
@@ -1,6 +1,5 @@
 """Switch platform for Eldom integration."""
 
-import logging
 from typing import Any
 
 from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
@@ -21,9 +20,6 @@ from .eldom_boiler import EldomBoiler
 from .models import EldomData
 
 SWITCH_NAME = "Powerful"
-
-_LOGGER = logging.getLogger(__name__)
-
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -107,11 +103,8 @@ class EldomBoilerPowerfulModeSwitch(SwitchEntity, CoordinatorEntity):
         self.schedule_update_ha_state()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
-        """Turn powerful off."""
-        _LOGGER.warning(
-            "Powerful mode cannot be turned off, change the mode to something else to disable the powerful mode"
-        )
-
+        """Turn powerful mode off by cycling off then restoring the previous mode."""
+        await self._eldom_boiler.disable_powerful_mode()
         await self.coordinator.async_request_refresh()
 
     @callback


### PR DESCRIPTION
## Summary

- Adds `disable_powerful_mode()` to `EldomBoiler` base class and all three concrete implementations (`FlatEldomBoiler`, `SmartEldomBoiler`, `NaturelaEldomBoiler`)
- When called, saves the current operation mode, turns the boiler off, waits 1 second, then restores the previous mode — this clears the boost flag
- `async_turn_off` on the powerful switch now calls `disable_powerful_mode()` instead of just logging a warning

## Background

The Eldom API has no dedicated endpoint to disable boost/powerful mode. Experimentally confirmed that cycling off → restore previous mode clears the `HasBoost` flag. `setHeater: false` and re-sending the same state both do not work.

Closes #46

## Test plan

- [ ] Enable powerful mode on a flat boiler in Eco or Electric mode
- [ ] Turn off the powerful switch in HA — boiler should briefly go off then return to the previous mode
- [ ] Verify `HasBoost` is cleared (powerful switch shows off)
- [ ] Test from Off mode: boost should not be enabling from Off anyway, but disabling should be a no-op (off → off)

🤖 Generated with [Claude Code](https://claude.com/claude-code)