### PR TITLE
Cast hw_version and sw_version to string for HA 2026.12.0 compatibility

### DIFF
--- a/custom_components/eldom/climate.py
+++ b/custom_components/eldom/climate.py
@@ -88,8 +88,8 @@ class EldomConvectorHeaterEntity(ClimateEntity, CoordinatorEntity):
             identifiers={(DOMAIN, self._convector_heater.device_id)},
             manufacturer=MANUFACTURER_NAME,
             model=DEVICE_TYPE_MAPPING.get(self._convector_heater.type),
-            sw_version=self._convector_heater.software_version,
-            hw_version=self._convector_heater.hardware_version,
+            sw_version=str(self._convector_heater.software_version),
+            hw_version=str(self._convector_heater.hardware_version),
         )
 
     @property

--- a/custom_components/eldom/manifest.json
+++ b/custom_components/eldom/manifest.json
@@ -10,6 +10,6 @@
   "issue_tracker": "https://github.com/qbaware/homeassistant-eldom/issues",
   "requirements": ["pyeldom==2.1.0"],
   "ssdp": [],
-  "version": "7.2.0",
+  "version": "7.3.0",
   "zeroconf": []
 }

--- a/custom_components/eldom/manifest.json
+++ b/custom_components/eldom/manifest.json
@@ -10,6 +10,6 @@
   "issue_tracker": "https://github.com/qbaware/homeassistant-eldom/issues",
   "requirements": ["pyeldom==2.1.0"],
   "ssdp": [],
-  "version": "7.3.0",
+  "version": "7.2.1",
   "zeroconf": []
 }

--- a/custom_components/eldom/water_heater.py
+++ b/custom_components/eldom/water_heater.py
@@ -111,8 +111,8 @@ class EldomWaterHeaterEntity(WaterHeaterEntity, CoordinatorEntity):
             identifiers={(DOMAIN, self._eldom_boiler.device_id)},
             manufacturer=MANUFACTURER_NAME,
             model=DEVICE_TYPE_MAPPING.get(self._eldom_boiler.type),
-            sw_version=self._eldom_boiler.software_version,
-            hw_version=self._eldom_boiler.hardware_version,
+            sw_version=str(self._eldom_boiler.software_version),
+            hw_version=str(self._eldom_boiler.hardware_version),
         )
 
     @property


### PR DESCRIPTION
## Summary

- `HardwareVersion` and `SoftwareVersion` in pyeldom models are typed as `int`, but Home Assistant's device registry requires string values for `hw_version` / `sw_version`
- HA logs a deprecation warning today and will stop working in HA 2026.12.0
- Wrap both values with `str()` when constructing `DeviceInfo`
- Bump version to `7.3.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)