### PR TITLE
Raise ConfigEntryAuthFailed on invalid credentials

### DIFF
--- a/custom_components/eldom/__init__.py
+++ b/custom_components/eldom/__init__.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import logging
 
+from eldom.client import InvalidCredentialsError as EldomInvalidCredentialsError
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import aiohttp_client
+from ioteldom.client import InvalidCredentialsError as IoTEldomInvalidCredentialsError
 
 from .const import CONF_API, DOMAIN
 from .coordinator import EldomCoordinator
@@ -37,7 +39,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     client = EldomClientWrapper(session, username, password, api)
 
     await client.login()
-    connected = await client.is_connected()
+
+    try:
+        connected = await client.is_connected()
+    except (EldomInvalidCredentialsError, IoTEldomInvalidCredentialsError) as err:
+        _LOGGER.error(
+            "Invalid credentials for Eldom API '%s' for '%s'", api, username
+        )
+        raise ConfigEntryAuthFailed(
+            f"Invalid credentials for Eldom API '{api}' for '{username}'"
+        ) from err
+
     if connected is False:
         _LOGGER.error(
             "Unexpected exception while authenticating with Eldom API '%s' for '%s'",

--- a/custom_components/eldom/manifest.json
+++ b/custom_components/eldom/manifest.json
@@ -8,8 +8,8 @@
   "homekit": {},
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/qbaware/homeassistant-eldom/issues",
-  "requirements": ["pyeldom==2.1.0"],
+  "requirements": ["pyeldom==2.1.1"],
   "ssdp": [],
-  "version": "7.3.0",
+  "version": "7.3.1",
   "zeroconf": []
 }


### PR DESCRIPTION
## Summary

- Closes #28
- `async_setup_entry` now catches the new `InvalidCredentialsError` from pyeldom and raises `ConfigEntryAuthFailed` instead of the generic `ConfigEntryNotReady`
- Effect: a user with a wrong/expired password gets HA's reauth flow instead of silent infinite retries

## Blocked on

qbaware/pyeldom#7 — `eldom.client.InvalidCredentialsError` and `ioteldom.client.InvalidCredentialsError` don't exist in the currently-pinned `pyeldom==2.1.0`. Once #7 is merged and published to PyPI:
1. Bump the `requirements` pin in `manifest.json` to the new pyeldom version
2. This PR should then be testable/mergeable

Not marked draft since GitHub doesn't let me from here, but treat it as one until the pyeldom side lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)