### PR TITLE
Document missing sensors, buttons, and the IoT flat boiler device type

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,16 @@ Devices managed via the `Eldom` app (or the `iot.myeldom.com` website) — see t
   - Chamber 1 temperature
   - Chamber 2 temperature
 
+#### 6. IoT convector heaters
+
+Devices managed via the `Eldom` app (or the `iot.myeldom.com` website) — see the [experimental support note](#supported-devices) above.
+
+- Operational mode selection
+  - `Heat`
+  - `Off`
+- Set target temperature
+- Display current temperature
+
 ### Showcase
 
 ![Flat boiler detailed view](./docs/flat-boiler-detailed-view-new.png)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This integration allows you to control Eldom devices via Home Assistant.
 
 Note that there's only one way to control your Eldom devices - via their Cloud APIs. There's no support for local network control.
 
-#### 1. Flat boilers
+### 1. Flat boilers
 
 - Operational mode selection
   - `Electric` (corresponds to "Heating")
@@ -44,7 +44,7 @@ Note that there's only one way to control your Eldom devices - via their Cloud A
   - Energy usage reset date
 - `Reset Energy Usage` button
 
-#### 2. Smart boilers
+### 2. Smart boilers
 
 - Operational mode selection
   - `Electric` (corresponds to "Heating")
@@ -62,7 +62,7 @@ Note that there's only one way to control your Eldom devices - via their Cloud A
   - Energy usage reset date
 - `Reset Energy Usage` button
 
-#### 3. Naturela boilers
+### 3. Naturela boilers
 
 - Operational mode selection
   - `Electric` (corresponds to "On")
@@ -82,7 +82,7 @@ Note that there's only one way to control your Eldom devices - via their Cloud A
   - Electric heater activation temperature
 - `Reset Energy Usage` button
 
-#### 4. Convector heaters
+### 4. Convector heaters
 
 - Operational mode selection
   - `Heat`
@@ -90,7 +90,7 @@ Note that there's only one way to control your Eldom devices - via their Cloud A
 - Set target temperature
 - Display current temperature
 
-#### 5. IoT flat boilers
+### 5. IoT flat boilers
 
 Devices managed via the `Eldom` app (or the `iot.myeldom.com` website) — see the [experimental support note](#supported-devices) above.
 
@@ -106,7 +106,7 @@ Devices managed via the `Eldom` app (or the `iot.myeldom.com` website) — see t
   - Chamber 1 temperature
   - Chamber 2 temperature
 
-#### 6. IoT convector heaters
+### 6. IoT convector heaters
 
 Devices managed via the `Eldom` app (or the `iot.myeldom.com` website) — see the [experimental support note](#supported-devices) above.
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Note that there's only one way to control your Eldom devices - via their Cloud A
   - Day energy consumption
   - Night energy consumption
   - Saved energy
+  - Energy usage reset date
+- `Reset Energy Usage` button
 
 #### 2. Smart boilers
 
@@ -57,6 +59,8 @@ Note that there's only one way to control your Eldom devices - via their Cloud A
   - Day energy consumption
   - Night energy consumption
   - Saved energy
+  - Energy usage reset date
+- `Reset Energy Usage` button
 
 #### 3. Naturela boilers
 
@@ -64,12 +68,19 @@ Note that there's only one way to control your Eldom devices - via their Cloud A
   - `Electric` (corresponds to "On")
   - `Eco` (corresponds to "Holiday")
   - `Off`
+- Set target temperature
 - Display current temperature
 - Enable `Powerful mode` switch (only works while the boiler is not off)
 - Display sensors
   - Heater is currently on/off
   - Day energy consumption
   - Night energy consumption
+  - Energy usage reset date
+  - Solar collector temperature
+  - Boiler intake temperature
+  - Tank temperature (top, middle, and bottom zones)
+  - Electric heater activation temperature
+- `Reset Energy Usage` button
 
 #### 4. Convector heaters
 
@@ -78,6 +89,22 @@ Note that there's only one way to control your Eldom devices - via their Cloud A
   - `Off`
 - Set target temperature
 - Display current temperature
+
+#### 5. IoT flat boilers
+
+Devices managed via the `Eldom` app (or the `iot.myeldom.com` website) — see the [experimental support note](#supported-devices) above.
+
+- Operational mode selection
+  - `Electric` (corresponds to "Extra safe")
+  - `Eco` (corresponds to "Eco")
+  - `High Demand` (corresponds to "Smart")
+  - `Performance` (corresponds to "Powerful")
+  - `Off`
+- Display current temperature (no target temperature control yet)
+- Display sensors
+  - Heater is currently on/off
+  - Chamber 1 temperature
+  - Chamber 2 temperature
 
 ### Showcase
 


### PR DESCRIPTION
## Summary

Fills gaps found by an independent review comparing the README against `const.py`, `sensor.py`, `water_heater.py`, and `button.py`:

- Energy Usage Reset Date sensor + Reset Energy Usage button (Flat/Smart/Naturela boilers) — existed in code, never documented
- 6 Naturela temperature sensors (solar, boiler intake, tank top/middle/bottom, heater activation) + target temperature control
- New "IoT flat boilers" §5 — operation modes, current temp, Heater/Chamber 1/Chamber 2 sensors from #45 — had no Features coverage at all

Convector heaters section was already accurate, no changes there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)